### PR TITLE
Hav 0015 hero section whitespace

### DIFF
--- a/_source/js/_cb6.js
+++ b/_source/js/_cb6.js
@@ -1,0 +1,73 @@
+//
+import { debounce } from "./_debounce-throttle.js";
+
+(function (document, window, $) {
+  if (!$) {
+    console.error("jQuery not loaded for adjust-gradient-lines.js");
+    return;
+  }
+
+  /**
+   * Adjusts the position of a gradient line on cb6 heros w/ no image.
+   * It reads the banner's padding-bottom, calculates a new bottom position as
+   * (padding-bottom / 2) - 2px, and sets this as a CSS custom property
+   * (--actual-padding-bottom) on the banner.
+   */
+  function adjustGradientLinePosition() {
+    // Target elements with both .cb6-interior-banner AND .no-image classes
+    const $banners = $(".cb6-interior-banner.no-image");
+    const strokeWidthAdjustment = 2; // The 2px to subtract, accounting for stroke width
+
+    if (!$banners.length) {
+      return;
+    }
+
+    $banners.each(function () {
+      const $banner = $(this); // Current banner
+      // Get the current padding-bottom.
+      const paddingBottomString = $banner.css("padding-bottom");
+
+      // Parse the string value to a number (e.g., "50px" -> 50)
+      const numericPaddingBottom = parseFloat(paddingBottomString);
+
+      // Check if parsing was successful
+      if (isNaN(numericPaddingBottom)) {
+        console.warn(
+          "Could not parse padding-bottom value:",
+          paddingBottomString,
+          "for element:",
+          $banner[0],
+        );
+        return;
+      }
+
+      // Calculate the new bottom value
+      const adjustedBottomValue =
+        numericPaddingBottom / 2 - strokeWidthAdjustment;
+
+      // Convert back to a string with "px"
+      const finalCssValue = adjustedBottomValue + "px";
+
+      // Set the SCSS custom property on the banner element
+      // This variable positions the line.
+      $banner.css("--actual-padding-bottom", finalCssValue);
+    });
+  }
+
+  // Run the adjustment function when the window is loaded
+  $(window).on("load", () => {
+    adjustGradientLinePosition(); // Call on initial load
+
+    // DEBOUNCED RESIZE HANDLER
+    // If debounce is not available, the resize handler will run on every resize event.
+    let resizeHandler = adjustGradientLinePosition; // Default to direct call
+
+    // Check if your specific debounce function is available and how to call it
+    if (typeof debounce === "function") {
+      console.log("debounce");
+      resizeHandler = debounce(adjustGradientLinePosition, 250);
+    }
+    // Listen for window resize events to re-adjust the line position
+    $(window).on("resize", resizeHandler);
+  });
+})(document, window, jQuery);

--- a/_source/js/scripts.js
+++ b/_source/js/scripts.js
@@ -3,6 +3,7 @@ import "./_thinkco-buttons";
 import "./_site-header";
 import "./_cb1";
 import "./_cb3";
+import "./_cb6";
 import "./_cb8";
 import "./_cb13";
 import "./_cb17";

--- a/_source/scss/_cb-6.scss
+++ b/_source/scss/_cb-6.scss
@@ -3,16 +3,19 @@
 //
 .cb6-interior-banner {
   //
+  //? bottom values are calculated in _cb6.js | specifically for the .no-image use case
   @include gradientBorder();
   @include gradientBorder(after, 90deg, 55%, 2px);
   &::after,
   &::before {
     left: 30px;
-    bottom: 120px;
+    // bottom: 120px;
+    bottom: var(--actual-padding-bottom, 120px);
+    //
     @include media("<small") {
       left: 12px;
-      bottom: 140px;
-      // bottom: 60px;
+      // bottom: 140px;
+      bottom: var(--actual-padding-bottom, 140px);
     }
   }
 
@@ -60,7 +63,7 @@
     //? Enforce vertical stacking
     @include media("<=1080px") {
       //? Add breathing room for section below
-      margin-bottom: 12vw;
+      // margin-bottom: 12vw;
       .fusion-layout-column {
         width: 100%;
         .fusion-column-wrapper {
@@ -158,19 +161,36 @@
     //*
     //* For pages without the images column, unset the body copy max-width
     .fusion-builder-row {
-      @include media("<=1080px") {
-        //? Add breathing room for section below
-        margin-bottom: 50vw !important;
+      // @include media(">1080px") {
+      //   //? Add breathing room for section below
+      //   margin-bottom: 72px;
+      // }
+      // @include media("<=1080px") {
+      //   //? Add breathing room for section below
+      //   margin-bottom: 36px;
+      // }
+
+      // //? Add margin bottom to last direct child inside the first column
+      // //? This will solve for the event where we dont keep the button el, which pushes down the ornament lines
+      .fusion-layout-column:first-of-type {
+        > *:last-child {
+          //* margin reset for no-image hero
+          margin-bottom: unset;
+          //*
+          //? hardcoded solution for whitespae
+          // padding: 0;
+          //
+          // @include media("<=1080px") {
+          //   margin-bottom: 48px;
+          // }
+          // @include media("<=small") {
+          //   margin-bottom: 20px;
+          // }
+        }
       }
 
-      // If there's only one column, adjust the fusion-text
       > .fusion-layout-column:only-child {
-        .fusion-column-wrapper {
-          //?
-          //
-          //
-        }
-
+        // If there's only one column, adjust the fusion-text
         .fusion-title + .fusion-text p {
           padding-right: unset;
         }

--- a/_source/scss/_cb-6.scss
+++ b/_source/scss/_cb-6.scss
@@ -158,9 +158,19 @@
     //*
     //* For pages without the images column, unset the body copy max-width
     .fusion-builder-row {
+      @include media("<=1080px") {
+        //? Add breathing room for section below
+        margin-bottom: 50vw !important;
+      }
+
       // If there's only one column, adjust the fusion-text
       > .fusion-layout-column:only-child {
-        // width: 100%;
+        .fusion-column-wrapper {
+          //?
+          //
+          //
+        }
+
         .fusion-title + .fusion-text p {
           padding-right: unset;
         }


### PR DESCRIPTION
A more dynamic solution to solve for whitespace.

- Takes the current padding value on the container and set the bottom of the gradient lines to its halfway point.
- Mimicking the debounce we used on cb17 for when we resize the window.
- NOTE: need to make sure we eliminate the extra paddings on the avada side - which create additional spacing.