### PR TITLE
text scaling fixes. adjusting for manual font overrides

### DIFF
--- a/_source/scss/_base-typography.scss
+++ b/_source/scss/_base-typography.scss
@@ -52,18 +52,21 @@ $rfs-factor: 80;
 }
 //	custom font value
 //
+//? --h6 override was not scaling, so also set this onto the font-size declaration
+//? For some reason not all use cases have a space in the style declaration...
+*[style*="--awb-font-size: 32px;"],
 *[style*="--awb-font-size:32px;"] {
   @include rfs(32px !important, --h6_typography-font-size);
-  // @include media("<=small") {
-  // 	--awb-font-size: 16px !important;
-  // }
+  @include rfs(32px !important, font-size);
 }
-*[style*="--awb-font-size: 24px;"] {
-  // @include rfs(24px !important, --awb-font-size);
-  @include rfs(20px !important, --awb-font-size);
-  @include media("<=small") {
-    --awb-font-size: 16px !important;
-  }
+//
+*[style*="--awb-font-size: 24px;"],
+*[style*="--awb-font-size:24px;"] {
+  @include rfs(24px !important, --awb-font-size);
+  // @include rfs(20px !important, --awb-font-size);
+  // @include media("<=small") {
+  //   --awb-font-size: 16px !important;
+  // }
 }
 //	custom font value
 //


### PR DESCRIPTION
Stubborn bug fixes
- We need to make sure the font size is "clicked into" on the avada side, or else the element wont gain the --awb style declaration
- When manually overriding sizes, we need to make sure a rfs override is put in this file if we need that text to scale.

Note to self: Check all instances of h4/h6 on the Avada side^