### PR TITLE
fixed custom button - white version

### DIFF
--- a/_source/scss/_site-header.scss
+++ b/_source/scss/_site-header.scss
@@ -164,6 +164,14 @@ html body {
 
   &.single.single-post {
     .fusion-tb-header {
+      //? Header for Wealth Planning posts
+      & .header-on-gold {
+        .menu-item {
+          //? Quality Blue
+          --awb-active-color: var(--awb-color8) !important;
+        }
+      }
+
       .fusion-search-button {
         &::before {
           filter: brightness(100);

--- a/_source/scss/_site-header.scss
+++ b/_source/scss/_site-header.scss
@@ -175,13 +175,14 @@ html body {
       }
 
       .fusion-button.think-custom-button.has-white-bg-color {
+        $button--color-1: #ffffff;
         box-shadow: inset 0 0 0 1px $button--color-1 !important; // simulating inset border
         .button__ornament {
           &-top-bottom,
           &-left-right {
             &:before,
             &:after {
-              background-color: var(--awb-custom_color_5);
+              background-color: $button--color-1;
             }
           }
         }


### PR DESCRIPTION
A bug flew under the radar! When on a post using the "all white" header, the client login button is also supposed to be white - no gold. (screenshot of issue below)
![image](https://github.com/user-attachments/assets/7c4002a8-233c-469f-9ffa-ccf26a40d72a)

Turns out we were never reassigning the button-color-1 variable for the has-white instance, and were the bg color to the gold.

Screenshot below of style guide rules
![image](https://github.com/user-attachments/assets/3808756e-1ddb-4eb0-bbd6-75718dee8663)


