### PR TITLE
Hav 0227 mobile team member cards

### DIFF
--- a/_source/scss/cb-8/_card.scss
+++ b/_source/scss/cb-8/_card.scss
@@ -13,6 +13,13 @@
       padding: 50px;
     }
   }
+  // TODO: We may want to revisit adding this so all post grids are consistent i.e News and Insights
+  @include media("<=small") {
+    .fusion-grid-posts-cards {
+      //? matches filter padding in filterset
+      // padding: 28px;
+    }
+  }
 }
 
 //

--- a/_source/scss/pages/_our-team.scss
+++ b/_source/scss/pages/_our-team.scss
@@ -2,7 +2,43 @@
 //
 //
 //
+
 body.page-id-515 {
+  //
+  @include media("<=small") {
+    .team-member-card {
+      container-type: inline-size;
+      container-name: team-card;
+      > .fusion-column-wrapper {
+        flex-direction: row !important;
+        gap: 1rem;
+        //
+        .fusion-classic-product-image-wrapper {
+          width: 33cqw; // 40% of container width (cqw = container query width unit)
+          // width: 40%;
+          // max-width: 175px;
+          aspect-ratio: 1 / 1;
+          flex: 0 0 auto;
+          .fusion-image-wrapper img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+          }
+        }
+        //
+        .team-member-card--metadata {
+          .fusion-title {
+            margin: 0 !important;
+          }
+          .fusion-column-wrapper {
+            flex-direction: column !important;
+            gap: 0.5rem;
+          }
+        }
+      }
+    }
+  }
   //
   .fusion-counters-box .fusion-counter-box {
     padding: 0px;
@@ -37,11 +73,24 @@ body.page-id-515 {
     padding: 13px;
   }
   //
+  .fusion-post-cards {
+    @include media("<=small") {
+      .fusion-grid-posts-cards {
+        //? matches filter padding in filterset
+        padding: 28px;
+      }
+    }
+  }
+  //
   // ? Ajax Search Pro section...
   //
   .searchrow {
     border: 1px solid #dcdcdc;
     padding: 50px;
+    @include media("<=small") {
+      padding: 28px;
+    }
+
     .title-heading-left {
       color: var(--awb-color8);
       font-family: var(--awb-custom_typography_1-font-family);

--- a/_source/scss/pages/_our-team.scss
+++ b/_source/scss/pages/_our-team.scss
@@ -9,16 +9,16 @@ body.page-id-515 {
     .team-member-card {
       container-type: inline-size;
       container-name: team-card;
+      //
       > .fusion-column-wrapper {
         flex-direction: row !important;
         gap: 1rem;
         //
         .fusion-classic-product-image-wrapper {
-          width: 33cqw; // 40% of container width (cqw = container query width unit)
-          // width: 40%;
-          // max-width: 175px;
+          width: 33cqw;
           aspect-ratio: 1 / 1;
           flex: 0 0 auto;
+          //
           .fusion-image-wrapper img {
             width: 100%;
             height: 100%;


### PR DESCRIPTION
Will + Allison approved the latest update (screenshot below) Updated the mobile layout of team member cards. 

![image](https://github.com/user-attachments/assets/00fab03c-0598-42a1-b048-ef92ed378ecb)

Steps to take on the Avada side:
- Move metadata into a nested column -- allows for the flex functionality when all grouped.
- Add necessary classes (team-member-card and team-member-card--metadata)
- Delete random "excerpt" field.. this was in the team card but isnt used/doesnt show anything.
- Remove extra margin bottom on nested column card