### PR TITLE
apply same styling for cloned must have page (nurture campaign)

### DIFF
--- a/_source/scss/pages/_must-have.scss
+++ b/_source/scss/pages/_must-have.scss
@@ -1,11 +1,13 @@
 //
 //
 //
-//? PAGE ID TARGETING FOR LOCAL, DEV, and PROD
-//* Manual overrides for Must Have LP //*
+//? PAGE ID TARGETING FOR LOCAL, DEV, and PROD Must-Have
+//* Manual overrides for Must Have LP *//
 body.page-id-70329,
 body.page-id-70346,
-body.page-id-70426 {
+body.page-id-70426,
+//? PAGE ID FOR NURTURE CAMPAIGN (cloned from Must-Have)
+body.page-id-70588 {
   //* ************
   //* HERO SECTION
   //* ************


### PR DESCRIPTION
Since we cloned the Must Have LP, we need to add the new page ID for the special image treatments/form styling/etc. Before/after shown below:
<img width="972" height="1154" alt="image" src="https://github.com/user-attachments/assets/e94ddc96-b0b1-47e6-918f-5346a27b51af" />
